### PR TITLE
Expose Session ID

### DIFF
--- a/lib/sma_api/client.rb
+++ b/lib/sma_api/client.rb
@@ -9,6 +9,10 @@ module SmaApi
       @client = Http.new(host: host, password: password, sid: sid)
     end
 
+    def sid
+      @client.sid
+    end
+
     def get_values(keys)
       result = @client.post('/dyn/getValues.json', { destDev: [], keys: keys })
       return nil unless result['result']

--- a/lib/sma_api/http.rb
+++ b/lib/sma_api/http.rb
@@ -4,9 +4,8 @@ require 'json'
 require 'net/http'
 
 module SmaApi
+  # Http wrapper
   class Http
-    attr_accessor :sid
-
     def initialize(host:, password:, sid: nil)
       @host = host
       @password = password
@@ -26,6 +25,12 @@ module SmaApi
       raise SmaApi::Error, 'Creating session failed' unless result['sid']
 
       @sid = result['sid']
+    end
+
+    def sid
+      create_session if @sid.empty?
+
+      @sid
     end
 
     def destroy_session

--- a/spec/cassettes/SmaApi_Client/_sid/1_2_1.yml
+++ b/spec/cassettes/SmaApi_Client/_sid/1_2_1.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<SMA_API_HOST>/dyn/login.json
+    body:
+      encoding: UTF-8
+      string: '{"right":"usr","pass":"<SMA_API_WEB_PASSWORD>"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Length:
+      - '37'
+      Date:
+      - Sat, 06 Jun 2020 12:54:37 GMT
+      Server:
+      - lighttpd/1.4.48
+    body:
+      encoding: UTF-8
+      string: '{"result":{"sid":"6UBJRT24Yog4xR2C"}}'
+    http_version: null
+  recorded_at: Sat, 06 Jun 2020 12:54:37 GMT
+recorded_with: VCR 5.1.0

--- a/spec/sma_api/client_spec.rb
+++ b/spec/sma_api/client_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe SmaApi::Client do
     end
   end
 
+  describe '#sid', :vcr do
+    subject { client.sid }
+
+    it { is_expected.to match(/\w{16}/) }
+  end
+
   describe '#get_values', :vcr do
     let(:keys) { %w[6100_40263F00 6400_00260100] }
     let(:result) do


### PR DESCRIPTION
Users should be able to supply the `sid` so it can be used for multiple subsequent requests